### PR TITLE
Apply global auth dependency

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,36 @@
+from fastapi import Depends, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from firebase_admin import auth as firebase_auth
+
+from .models import User
+from .services.db import db
+
+security = HTTPBearer()
+
+
+async def get_current_user(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> User:
+    """Verify Firebase token, store and return the current user."""
+    try:
+        decoded_token = firebase_auth.verify_id_token(credentials.credentials)
+        firebase_uid = decoded_token["uid"]
+
+        user_doc = await db.users.find_one({"firebase_uid": firebase_uid})
+        if not user_doc:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        user = User(**user_doc)
+        request.state.user = user
+        return user
+    except Exception as e:  # pragma: no cover - network / firebase failures
+        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}")
+
+
+def current_user(request: Request) -> User:
+    """Retrieve the authenticated user from the request state."""
+    user = getattr(request.state, "user", None)
+    if user is None:
+        raise HTTPException(status_code=401, detail="User not authenticated")
+    return user

--- a/backend/server.py
+++ b/backend/server.py
@@ -3,7 +3,7 @@ from starlette.middleware.cors import CORSMiddleware
 import logging
 
 from .services.db import client, init_firebase
-from .routes.api import router as api_router
+from .routes.api import public_router, protected_router
 
 app = FastAPI(
     title="MCP-CMS",
@@ -11,7 +11,8 @@ app = FastAPI(
 )
 
 # Register API routes
-app.include_router(api_router)
+app.include_router(public_router)
+app.include_router(protected_router)
 
 # CORS middleware
 app.add_middleware(

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -1,25 +1,4 @@
-from fastapi import Depends, HTTPException
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from firebase_admin import auth as firebase_auth
+"""Compatibility layer importing the authentication helpers."""
 
-from .db import db
-from ..models import User
+from ..auth import get_current_user  # noqa: F401
 
-security = HTTPBearer()
-
-
-async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
-) -> User:
-    """Verify Firebase token and get user."""
-    try:
-        decoded_token = firebase_auth.verify_id_token(credentials.credentials)
-        firebase_uid = decoded_token['uid']
-
-        user_doc = await db.users.find_one({"firebase_uid": firebase_uid})
-        if not user_doc:
-            raise HTTPException(status_code=404, detail="User not found")
-
-        return User(**user_doc)
-    except Exception as e:
-        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}")


### PR DESCRIPTION
## Summary
- add `backend/auth.py` to centralize user authentication
- apply router-level auth dependency in `backend/routes/api.py`
- expose public and protected routers in `server.py`
- keep backwards compatible `services/auth.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68692ffc6864832ebe1449be0697688a