### PR TITLE
Add backend+frontend tests with CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install backend dependencies
+        run: python -m pip install -r backend/requirements.txt
+      - name: Run backend tests
+        run: pytest
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'yarn'
+          cache-dependency-path: frontend/yarn.lock
+      - name: Install frontend dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: frontend
+      - name: Run frontend tests
+        run: yarn test --watchAll=false
+        working-directory: frontend

--- a/frontend/src/__tests__/Login.test.js
+++ b/frontend/src/__tests__/Login.test.js
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import Login from '../components/Login';
+
+test('renders Sign In heading', () => {
+  render(<Login />);
+  expect(screen.getByRole('heading', { name: /sign in/i })).toBeInTheDocument();
+});

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,14 @@
+import os
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("MONGO_URL", "mongodb://localhost:27017")
+os.environ.setdefault("DB_NAME", "testdb")
+os.environ.setdefault("FIREBASE_SERVICE_ACCOUNT", "{}")
+
+from backend.server import app
+
+client = TestClient(app)
+
+def test_auth_me_requires_authentication():
+    response = client.get("/api/auth/me")
+    assert response.status_code == 401

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,17 @@
+import os
+from fastapi.testclient import TestClient
+
+# Ensure required environment variables for db init
+os.environ.setdefault("MONGO_URL", "mongodb://localhost:27017")
+os.environ.setdefault("DB_NAME", "testdb")
+os.environ.setdefault("FIREBASE_SERVICE_ACCOUNT", "{}")
+
+from backend.server import app
+
+client = TestClient(app)
+
+def test_health_check():
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "healthy"


### PR DESCRIPTION
## Summary
- add basic backend tests for health and auth
- add example React test for Login component
- run tests in CI via GitHub Actions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*
- `yarn test --watchAll=false` in `frontend` *(fails: cannot fetch yarn package)*
