### PR TITLE
Add backend unit tests with pytest fixtures

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+addopts = -vv
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,79 @@
+import os
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure environment variables so server initializes
+os.environ.setdefault("MONGO_URL", "mongodb://localhost:27017")
+os.environ.setdefault("DB_NAME", "testdb")
+os.environ.setdefault("FIREBASE_SERVICE_ACCOUNT", "{}")
+
+from backend.server import app
+from backend.models import UserRole
+from backend.services import db as db_module
+
+
+class FakeCollection:
+    def __init__(self):
+        self.storage = {}
+
+    async def find_one(self, query):
+        if "firebase_uid" in query:
+            return self.storage.get(query["firebase_uid"])
+        if "id" in query:
+            return self.storage.get(query["id"])
+        return None
+
+    async def insert_one(self, doc):
+        key = doc.get("firebase_uid") or doc.get("id")
+        self.storage[key] = doc
+        return AsyncMock(inserted_id=key)
+
+
+class FakeDB:
+    def __init__(self):
+        self.users = FakeCollection()
+        self.pages = FakeCollection()
+        self.articles = FakeCollection()
+        self.categories = FakeCollection()
+
+
+@pytest.fixture(autouse=True)
+def fake_db(monkeypatch):
+    db = FakeDB()
+    monkeypatch.setattr(db_module, "db", db)
+    yield db
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_firebase(monkeypatch):
+    from firebase_admin import auth as firebase_auth
+
+    def fake_verify(token):
+        return {"uid": "testuid"}
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", fake_verify)
+
+
+@pytest.fixture
+def seed_user(fake_db):
+    user_doc = {
+        "id": "user1",
+        "firebase_uid": "testuid",
+        "email": "test@example.com",
+        "name": "Test User",
+        "role": UserRole.ADMIN.value,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+        "is_active": True,
+    }
+    fake_db.users.storage[user_doc["firebase_uid"]] = user_doc
+    return user_doc
+

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,14 +1,33 @@
-import os
 from fastapi.testclient import TestClient
-
-os.environ.setdefault("MONGO_URL", "mongodb://localhost:27017")
-os.environ.setdefault("DB_NAME", "testdb")
-os.environ.setdefault("FIREBASE_SERVICE_ACCOUNT", "{}")
 
 from backend.server import app
 
 client = TestClient(app)
 
+
 def test_auth_me_requires_authentication():
     response = client.get("/api/auth/me")
     assert response.status_code == 401
+
+
+def test_register_user_success(client, fake_db):
+    payload = {
+        "firebase_uid": "newuid",
+        "email": "new@example.com",
+        "name": "New User",
+        "role": "viewer",
+    }
+    response = client.post("/api/auth/register", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["message"] == "User registered successfully"
+    assert payload["firebase_uid"] in fake_db.users.storage
+
+
+def test_auth_me_with_mocked_firebase(client, mock_firebase, seed_user):
+    headers = {"Authorization": "Bearer faketoken"}
+    response = client.get("/api/auth/me", headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["firebase_uid"] == seed_user["firebase_uid"]
+

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+from backend.server import app
+from backend.services.tools import tool_registry, Tool
+
+client = TestClient(app)
+
+
+class DummyTool(Tool):
+    def get_name(self) -> str:
+        return "dummyTool"
+
+    async def execute(self, args, user):
+        return {"echo": args, "user": user.id}
+
+
+def test_tool_dispatch(client, mock_firebase, seed_user):
+    tool = DummyTool()
+    tool_registry.register(tool)
+    try:
+        headers = {"Authorization": "Bearer faketoken"}
+        payload = {"tool": tool.get_name(), "args": {"a": 1}}
+        response = client.post("/api/mcp/dispatch", json=payload, headers=headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["data"]["echo"] == payload["args"]
+        assert data["data"]["user"] == seed_user["id"]
+    finally:
+        tool_registry.tools.pop(tool.get_name(), None)
+
+

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,17 +1,14 @@
-import os
 from fastapi.testclient import TestClient
-
-# Ensure required environment variables for db init
-os.environ.setdefault("MONGO_URL", "mongodb://localhost:27017")
-os.environ.setdefault("DB_NAME", "testdb")
-os.environ.setdefault("FIREBASE_SERVICE_ACCOUNT", "{}")
 
 from backend.server import app
 
 client = TestClient(app)
+
 
 def test_health_check():
     response = client.get("/api/health")
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "healthy"
+
+


### PR DESCRIPTION
## Summary
- add pytest configuration file
- add test fixtures and Firebase mocking for authentication
- test health check
- test user registration and current-user retrieval
- test tool dispatch logic with dummy tool

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
