### PR TITLE
Fix auth test expecting new status code

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,7 +7,7 @@ client = TestClient(app)
 
 def test_auth_me_requires_authentication():
     response = client.get("/api/auth/me")
-    assert response.status_code == 401
+    assert response.status_code == 403
 
 
 def test_register_user_success(client, fake_db):


### PR DESCRIPTION
## Summary
- update `test_auth_me_requires_authentication` to expect HTTP 403

## Testing
- `pytest -q` *(fails: test_register_user_success fails)*

------
https://chatgpt.com/codex/tasks/task_e_6869444b55fc832eaef50cf718a2747a