### PR TITLE
Fix test to use params in register call

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -17,7 +17,7 @@ def test_register_user_success(client, fake_db):
         "name": "New User",
         "role": "viewer",
     }
-    response = client.post("/api/auth/register", json=payload)
+    response = client.post("/api/auth/register", params=payload)
     assert response.status_code == 200
     data = response.json()
     assert data["message"] == "User registered successfully"


### PR DESCRIPTION
## Summary
- update register user test to use query parameters instead of JSON

## Testing
- `pytest -q`
