### PR TITLE
Add Docker Compose and CI pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+**/__pycache__
+*.pyc
+frontend/node_modules
+backend/.venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+      - name: Run tests
+        run: pytest
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'yarn'
+          cache-dependency-path: frontend/yarn.lock
+      - name: Install dependencies
+        working-directory: frontend
+        run: yarn install --frozen-lockfile
+      - name: Run linter
+        working-directory: frontend
+        run: npx eslint src --ext js,jsx

--- a/README.md
+++ b/README.md
@@ -52,3 +52,18 @@ Mit AMTLICH.AI beweisen wir:
 → MVP Release: Q4/2025  
 → Starte lokal mit `docker-compose` und deinem eigenen Claude oder GPT-Account.  
 → Beitrag willkommen! Siehe `CONTRIBUTING.md`.
+
+### Local Docker Setup
+
+1. Build and run all services:
+   ```bash
+   docker-compose up --build
+   ```
+2. Backend erreichbar unter [http://localhost:8000](http://localhost:8000)
+3. Frontend erreichbar unter [http://localhost:3000](http://localhost:3000)
+4. MongoDB läuft als Container und wird vom Backend automatisch über `mongodb://mongo:27017` angesprochen.
+
+Stoppe alle Dienste mit:
+```bash
+docker-compose down
+```

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.8'
+services:
+  mongo:
+    image: mongo:7
+    restart: unless-stopped
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+
+  backend:
+    build: ./backend
+    environment:
+      MONGO_URL: mongodb://mongo:27017
+      DB_NAME: amtlich
+      FIREBASE_SERVICE_ACCOUNT: '{}'
+    ports:
+      - "8000:8000"
+    depends_on:
+      - mongo
+
+  frontend:
+    build: ./frontend
+    environment:
+      REACT_APP_API_URL: http://localhost:8000
+      HOST: 0.0.0.0
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+
+volumes:
+  mongo-data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+COPY . .
+ENV HOST=0.0.0.0
+CMD ["yarn", "start"]

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,23 @@
+import js from '@eslint/js';
+import react from 'eslint-plugin-react';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
+import importPlugin from 'eslint-plugin-import';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.{js,jsx}'],
+    plugins: {
+      react,
+      'jsx-a11y': jsxA11y,
+      import: importPlugin
+    },
+    languageOptions: {
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module'
+      }
+    },
+    rules: {}
+  }
+];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "start": "craco start",
     "build": "craco build",
     "test": "craco test",
+    "lint": "eslint src --ext js,jsx",
     "eject": "react-scripts eject"
   },
   "browserslist": {


### PR DESCRIPTION
## Summary
- add Dockerfiles for backend and frontend
- orchestrate services with docker-compose and MongoDB
- document Docker workflow
- create ESLint config for the frontend
- add CI workflow running backend tests and frontend lint

## Testing
- `pytest -q`
- `yarn install --frozen-lockfile` *(fails: Request failed "503 Service Unavailable" for lodash.debounce)*

------
https://chatgpt.com/codex/tasks/task_e_686962d8bd3c832e8fc224dc37d76f20