### PR TITLE
Add role validation dependency and standardized errors

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,9 +1,11 @@
 import logging
+
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from firebase_admin import auth as firebase_auth
 
-from .models import User
+from .errors import ErrorResponse
+from .models import User, UserRole
 from .services.db import db
 
 security = HTTPBearer()
@@ -21,19 +23,50 @@ async def get_current_user(
 
         user_doc = await db.users.find_one({"firebase_uid": firebase_uid})
         if not user_doc:
-            raise HTTPException(status_code=404, detail="User not found")
+            raise HTTPException(
+                status_code=404,
+                detail=ErrorResponse(
+                    message="User not found", code="user_not_found"
+                ).dict(),
+            )
 
         user = User(**user_doc)
         request.state.user = user
         return user
     except Exception as e:  # pragma: no cover - network / firebase failures
         logger.exception("Authentication failed")
-        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}")
+        raise HTTPException(
+            status_code=401,
+            detail=ErrorResponse(
+                message=f"Authentication failed: {str(e)}", code="auth_failed"
+            ).dict(),
+        )
 
 
 def current_user(request: Request) -> User:
     """Retrieve the authenticated user from the request state."""
     user = getattr(request.state, "user", None)
     if user is None:
-        raise HTTPException(status_code=401, detail="User not authenticated")
+        raise HTTPException(
+            status_code=401,
+            detail=ErrorResponse(
+                message="User not authenticated", code="not_authenticated"
+            ).dict(),
+        )
     return user
+
+
+def require_roles(*roles: UserRole):
+    """Dependency to ensure the user has one of the required roles."""
+
+    async def _role_checker(request: Request) -> None:
+        user = current_user(request)
+        if user.role not in roles:
+            raise HTTPException(
+                status_code=403,
+                detail=ErrorResponse(
+                    message="Insufficient permissions", code="insufficient_role"
+                ).dict(),
+            )
+
+    return Depends(_role_checker)

--- a/backend/errors.py
+++ b/backend/errors.py
@@ -1,0 +1,8 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class ErrorResponse(BaseModel):
+    message: str
+    code: Optional[str] = None

--- a/backend/server.py
+++ b/backend/server.py
@@ -7,8 +7,8 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.cors import CORSMiddleware
 
+from .errors import ErrorResponse
 from .logging_config import setup_logging
-
 from .routes.api import protected_router, public_router
 from .services.db import client, init_firebase
 
@@ -57,7 +57,11 @@ async def shutdown_db_client():
 @app.exception_handler(HTTPException)
 async def handle_http_exception(request: Request, exc: HTTPException) -> JSONResponse:
     logger.warning("HTTPException: %s", exc.detail)
-    return JSONResponse(status_code=exc.status_code, content={"error": exc.detail})
+    if isinstance(exc.detail, dict):
+        error_detail = exc.detail
+    else:
+        error_detail = ErrorResponse(message=str(exc.detail)).dict()
+    return JSONResponse(status_code=exc.status_code, content={"error": error_detail})
 
 
 @app.exception_handler(Exception)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,8 @@ os.environ.setdefault("MONGO_URL", "mongodb://localhost:27017")
 os.environ.setdefault("DB_NAME", "testdb")
 os.environ.setdefault("FIREBASE_SERVICE_ACCOUNT", "{}")
 
-from backend.server import app
 from backend.models import UserRole
+from backend.server import app
 from backend.services import db as db_module
 
 
@@ -31,6 +31,9 @@ class FakeCollection:
         self.storage[key] = doc
         return AsyncMock(inserted_id=key)
 
+    async def count_documents(self, query):
+        return len(self.storage)
+
 
 class FakeDB:
     def __init__(self):
@@ -46,6 +49,7 @@ def fake_db(monkeypatch):
     monkeypatch.setattr(db_module, "db", db)
     from backend import auth
     from backend.routes import api as api_routes
+
     monkeypatch.setattr(auth, "db", db)
     monkeypatch.setattr(api_routes, "db", db)
     yield db
@@ -80,4 +84,3 @@ def seed_user(fake_db):
     }
     fake_db.users.storage[user_doc["firebase_uid"]] = user_doc
     return user_doc
-

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+
+from backend.models import UserRole
+
+
+def test_dashboard_stats_allows_admin(client, mock_firebase, seed_user):
+    headers = {"Authorization": "Bearer faketoken"}
+    response = client.get("/api/dashboard/stats", headers=headers)
+    assert response.status_code == 200
+
+
+def test_dashboard_stats_rejects_viewer(client, fake_db, monkeypatch):
+    from firebase_admin import auth as firebase_auth
+
+    def fake_verify(token):
+        return {"uid": "vieweruid"}
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", fake_verify)
+
+    viewer_doc = {
+        "id": "viewer1",
+        "firebase_uid": "vieweruid",
+        "email": "viewer@example.com",
+        "name": "Viewer",
+        "role": UserRole.VIEWER.value,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+        "is_active": True,
+    }
+    fake_db.users.storage[viewer_doc["firebase_uid"]] = viewer_doc
+
+    headers = {"Authorization": "Bearer viewertoken"}
+    response = client.get("/api/dashboard/stats", headers=headers)
+    assert response.status_code == 403
+    data = response.json()
+    assert data["error"]["message"] == "Insufficient permissions"


### PR DESCRIPTION
## Summary
- add `ErrorResponse` model for HTTP errors
- create `require_roles` dependency
- use standardized error responses in auth and tools
- restrict `/dashboard/stats` endpoint with role validation
- add tests for role validation

## Testing
- `pytest -q`
