### PR TITLE
Default viewer role on registration

### DIFF
--- a/MCP_DOCUMENTATION.md
+++ b/MCP_DOCUMENTATION.md
@@ -146,7 +146,7 @@ Erstellt einen neuen Benutzer (nur für Admins).
 - `GET /api/mcp/tools` - Liste verfügbarer Tools
 
 ### Authentication
-- `POST /api/auth/register` - Benutzer registrieren
+- `POST /api/auth/register` - Benutzer registrieren (Rolle wird immer als `viewer` gesetzt)
 - `GET /api/auth/me` - Aktuelle Benutzerinformationen
 
 ### Content Management

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ AMTLICH.AI ist ein **modularer MCP-Server** auf Basis von **FastAPI + MongoDB + 
 - `manageUsers()` – Rechteverwaltung & Redaktionsrollen
 - `uploadMedia()` – Mediendatenbank mit Drag’n’Drop
 - `promptQueue()` – Verarbeitung eingehender AI-Tasks
+- Neu registrierte Benutzer erhalten automatisch die Rolle `viewer`.
 
 ---
 

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -27,4 +27,3 @@ class RegisterUserRequest(BaseModel):
     firebase_uid: str
     email: str
     name: str
-    role: UserRole = UserRole.VIEWER

--- a/backend/routes/api.py
+++ b/backend/routes/api.py
@@ -70,7 +70,7 @@ async def register_user(registration: RegisterUserRequest):
             "firebase_uid": registration.firebase_uid,
             "email": registration.email,
             "name": registration.name,
-            "role": registration.role,
+            "role": UserRole.VIEWER,
         }
 
         user = User(**user_data)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,3 +1,6 @@
+from backend.models import UserRole
+
+
 def test_auth_me_requires_authentication(client):
     response = client.get("/api/auth/me")
     assert response.status_code == 403
@@ -8,13 +11,14 @@ def test_register_user_success(client, fake_db):
         "firebase_uid": "newuid",
         "email": "new@example.com",
         "name": "New User",
-        "role": "viewer",
     }
     response = client.post("/api/auth/register", json=payload)
     assert response.status_code == 200
     data = response.json()
     assert data["message"] == "User registered successfully"
     assert payload["firebase_uid"] in fake_db.users.storage
+    stored = fake_db.users.storage[payload["firebase_uid"]]
+    assert stored["role"] == UserRole.VIEWER.value
 
 
 def test_auth_me_with_mocked_firebase(client, mock_firebase, seed_user):


### PR DESCRIPTION
## Summary
- remove `role` from `RegisterUserRequest`
- enforce viewer role in `/auth/register`
- adjust tests for new default
- note viewer default in docs

## Testing
- `black backend tests`
- `flake8 backend tests`
- `pytest -q`
