### PR TITLE
Add DB index creation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,10 @@ Frontend-Tests startest du im `frontend`-Verzeichnis:
 yarn test
 ```
 
+## Deployment Notes
+
+Beim Start des Backends werden wichtige MongoDB-Indizes erzeugt. Dies umfasst
+einzigartige Indizes auf den Feldern `firebase_uid` und `id` der `users`
+Collection. Bei einem frischen Deployment stellt das Backend so sicher, dass
+Abfragen performant bleiben.
+

--- a/backend/server.py
+++ b/backend/server.py
@@ -10,7 +10,7 @@ from starlette.middleware.cors import CORSMiddleware
 from .errors import ErrorResponse
 from .logging_config import setup_logging
 from .routes.api import protected_router, public_router
-from .services.db import client, init_firebase
+from .services.db import client, init_firebase, ensure_indexes
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
 load_dotenv(ROOT_DIR / ".env")
@@ -46,6 +46,11 @@ logger = logging.getLogger(__name__)
 
 # Initialize Firebase when the module is imported
 init_firebase()
+
+
+@app.on_event("startup")
+async def startup_db_client():
+    await ensure_indexes()
 
 
 @app.on_event("shutdown")

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -19,6 +19,18 @@ db = client[os.environ["DB_NAME"]]
 logger = logging.getLogger(__name__)
 
 
+async def ensure_indexes() -> None:
+    """Create required MongoDB indexes if supported."""
+    try:
+        users = getattr(db, "users", None)
+        if users and hasattr(users, "create_index"):
+            await users.create_index("firebase_uid", unique=True)
+            await users.create_index("id", unique=True)
+            logger.info("MongoDB indexes ensured")
+    except Exception as e:  # pragma: no cover - index creation best effort
+        logger.exception("Failed to create indexes: %s", e)
+
+
 def init_firebase() -> None:
     """Initialize Firebase Admin SDK if credentials are provided."""
     try:


### PR DESCRIPTION
## Summary
- ensure MongoDB indexes for user collection at startup
- document these indexes in Deployment Notes section of README

## Testing
- `flake8 backend tests`
- `pytest -q`
- `yarn --cwd frontend lint`
- `yarn --cwd frontend prettier --check .`


