### PR TITLE
Require ALLOWED_ORIGINS at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Bevor du loslegst, installiere **Python 3.11**, **Node.js 20** und **Yarn**. Opt
 | `FIREBASE_SERVICE_ACCOUNT` | JSON mit Firebase-Credentials                                 | `{}`                             |
 | `AI_BASE_URL`            | Basis-URL eines externen AI-Dienstes                           | *(optional)*                     |
 | `AI_API_KEY`             | API-Key für den AI-Dienst                                      | *(optional)*                     |
-| `ALLOWED_ORIGINS`        | Kommagetrennte Liste erlaubter CORS-Origin                     | `*`                              |
+| `ALLOWED_ORIGINS`        | Kommagetrennte Liste erlaubter CORS-Origin            | `http://localhost:3000`          |
 | `REACT_APP_API_URL`      | API-Endpunkt für das Frontend                                  | `http://localhost:8000`          |
 
 Lege für das Backend eine `.env`-Datei an oder exportiere die Variablen in deiner Shell.

--- a/backend/server.py
+++ b/backend/server.py
@@ -10,17 +10,21 @@ from starlette.middleware.cors import CORSMiddleware
 from .errors import ErrorResponse
 from .logging_config import setup_logging
 from .routes.api import protected_router, public_router
-from .services.db import client, init_firebase, ensure_indexes
+from .services.db import client, ensure_indexes, init_firebase
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
 load_dotenv(ROOT_DIR / ".env")
 
-allowed_origins_env = os.getenv("ALLOWED_ORIGINS", "")
+# Parse allowed origins from the required environment variable
+allowed_origins_env = os.getenv("ALLOWED_ORIGINS")
+if not allowed_origins_env:
+    raise RuntimeError("ALLOWED_ORIGINS environment variable must be set")
+
 allowed_origins = [
     origin.strip() for origin in allowed_origins_env.split(",") if origin.strip()
 ]
 if not allowed_origins:
-    allowed_origins = ["*"]
+    raise RuntimeError("ALLOWED_ORIGINS environment variable must not be empty")
 
 app = FastAPI(
     title="MCP-CMS",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       MONGO_URL: mongodb://mongo:27017
       DB_NAME: amtlich
       FIREBASE_SERVICE_ACCOUNT: '{}'
+      ALLOWED_ORIGINS: http://localhost:3000
     ports:
       - "8000:8000"
     depends_on:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 os.environ.setdefault("MONGO_URL", "mongodb://localhost:27017")
 os.environ.setdefault("DB_NAME", "testdb")
 os.environ.setdefault("FIREBASE_SERVICE_ACCOUNT", "{}")
+os.environ.setdefault("ALLOWED_ORIGINS", "http://testserver")
 
 from backend.models import UserRole  # noqa: E402
 from backend.server import app  # noqa: E402


### PR DESCRIPTION
## Summary
- fail backend startup if `ALLOWED_ORIGINS` is missing or empty
- add `ALLOWED_ORIGINS` to docker-compose
- document the variable in README
- set default value for tests

## Testing
- `pytest -q`
