### PR TITLE
Implement CRUD operations for content

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,5 +1,14 @@
 from .user import UserRole, User, RegisterUserRequest
-from .content import Page, Article, Category, MediaFile
+from .content import (
+    Page,
+    Article,
+    Category,
+    MediaFile,
+    PageCreate,
+    PageUpdate,
+    ArticleCreate,
+    ArticleUpdate,
+)
 from .tool import ToolCall, ToolResponse
 
 __all__ = [
@@ -12,4 +21,8 @@ __all__ = [
     "ToolCall",
     "ToolResponse",
     "RegisterUserRequest",
+    "PageCreate",
+    "PageUpdate",
+    "ArticleCreate",
+    "ArticleUpdate",
 ]

--- a/backend/models/content.py
+++ b/backend/models/content.py
@@ -19,6 +19,28 @@ class Page(BaseModel):
     published_at: Optional[datetime] = None
 
 
+class PageCreate(BaseModel):
+    """Model for creating a new page."""
+
+    title: str
+    slug: Optional[str] = None
+    content: str = ""
+    meta_description: Optional[str] = None
+    parent_id: Optional[str] = None
+    status: str = "draft"
+
+
+class PageUpdate(BaseModel):
+    """Model for updating an existing page."""
+
+    title: Optional[str] = None
+    slug: Optional[str] = None
+    content: Optional[str] = None
+    meta_description: Optional[str] = None
+    parent_id: Optional[str] = None
+    status: Optional[str] = None
+
+
 class Article(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     title: str
@@ -33,6 +55,32 @@ class Article(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
     published_at: Optional[datetime] = None
+
+
+class ArticleCreate(BaseModel):
+    """Model for creating an article."""
+
+    title: str
+    slug: Optional[str] = None
+    content: str = ""
+    excerpt: Optional[str] = None
+    featured_image: Optional[str] = None
+    category_id: Optional[str] = None
+    tags: List[str] = []
+    status: str = "draft"
+
+
+class ArticleUpdate(BaseModel):
+    """Model for updating an article."""
+
+    title: Optional[str] = None
+    slug: Optional[str] = None
+    content: Optional[str] = None
+    excerpt: Optional[str] = None
+    featured_image: Optional[str] = None
+    category_id: Optional[str] = None
+    tags: Optional[List[str]] = None
+    status: Optional[str] = None
 
 
 class Category(BaseModel):

--- a/tests/test_content_endpoints.py
+++ b/tests/test_content_endpoints.py
@@ -1,0 +1,91 @@
+import datetime
+from backend.models import UserRole
+
+
+def test_create_page(client, mock_firebase, seed_user):
+    payload = {"title": "Test Page", "slug": "test-page", "content": "Body"}
+    headers = {"Authorization": "Bearer faketoken"}
+    response = client.post("/api/pages", json=payload, headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == payload["title"]
+
+
+def test_update_page_by_author(client, fake_db, monkeypatch):
+    from firebase_admin import auth as firebase_auth
+
+    def fake_verify(token):
+        return {"uid": "authoruid"}
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", fake_verify)
+
+    author_doc = {
+        "id": "author1",
+        "firebase_uid": "authoruid",
+        "email": "a@example.com",
+        "name": "Author",
+        "role": UserRole.AUTHOR.value,
+        "created_at": datetime.datetime.utcnow(),
+        "updated_at": datetime.datetime.utcnow(),
+        "is_active": True,
+    }
+    fake_db.users.storage[author_doc["firebase_uid"]] = author_doc
+
+    page_doc = {
+        "id": "page1",
+        "title": "Old",
+        "slug": "old",
+        "content": "c",
+        "author_id": author_doc["id"],
+        "status": "draft",
+        "created_at": datetime.datetime.utcnow(),
+        "updated_at": datetime.datetime.utcnow(),
+    }
+    fake_db.pages.storage[page_doc["id"]] = page_doc
+
+    headers = {"Authorization": "Bearer token"}
+    response = client.put(
+        f"/api/pages/{page_doc['id']}",
+        json={"title": "New"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert fake_db.pages.storage[page_doc["id"]]["title"] == "New"
+
+
+def test_delete_article_as_editor(client, fake_db, monkeypatch):
+    from firebase_admin import auth as firebase_auth
+
+    def fake_verify(token):
+        return {"uid": "editoruid"}
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", fake_verify)
+
+    editor_doc = {
+        "id": "editor1",
+        "firebase_uid": "editoruid",
+        "email": "e@example.com",
+        "name": "Editor",
+        "role": UserRole.EDITOR.value,
+        "created_at": datetime.datetime.utcnow(),
+        "updated_at": datetime.datetime.utcnow(),
+        "is_active": True,
+    }
+    fake_db.users.storage[editor_doc["firebase_uid"]] = editor_doc
+
+    article_doc = {
+        "id": "art1",
+        "title": "T",
+        "slug": "t",
+        "content": "c",
+        "author_id": editor_doc["id"],
+        "status": "draft",
+        "created_at": datetime.datetime.utcnow(),
+        "updated_at": datetime.datetime.utcnow(),
+    }
+    fake_db.articles.storage[article_doc["id"]] = article_doc
+
+    headers = {"Authorization": "Bearer token"}
+    response = client.delete(f"/api/articles/{article_doc['id']}", headers=headers)
+    assert response.status_code == 200
+    assert article_doc["id"] not in fake_db.articles.storage


### PR DESCRIPTION
## Summary
- add request models for page/article creation & updates
- implement protected CRUD endpoints for pages and articles
- extend fake DB helpers for update/delete/find
- test page/article endpoints

## Testing
- `flake8 backend tests`
- `pytest -q`
