### PR TITLE
Switch frontend env var to API_URL

### DIFF
--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -3,8 +3,8 @@ import axios from 'axios';
 import { AuthContext } from '../App';
 import MCPToolTester from './MCPToolTester';
 
-const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
-const API = `${BACKEND_URL}/api`;
+const API_BASE_URL = process.env.REACT_APP_API_URL;
+const API = `${API_BASE_URL}/api`;
 
 const Dashboard = () => {
   const [stats, setStats] = useState({});

--- a/frontend/src/components/MCPToolTester.js
+++ b/frontend/src/components/MCPToolTester.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 
-const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
-const API = `${BACKEND_URL}/api`;
+const API_BASE_URL = process.env.REACT_APP_API_URL;
+const API = `${API_BASE_URL}/api`;
 
 const MCPToolTester = () => {
   const [toolName, setToolName] = useState('createPage');

--- a/frontend/src/components/PagesList.js
+++ b/frontend/src/components/PagesList.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 
-const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
-const API = `${BACKEND_URL}/api`;
+const API_BASE_URL = process.env.REACT_APP_API_URL;
+const API = `${API_BASE_URL}/api`;
 
 const PagesList = () => {
   const [pages, setPages] = useState([]);


### PR DESCRIPTION
## Summary
- update frontend components to reference `REACT_APP_API_URL` rather than `REACT_APP_BACKEND_URL`

## Testing
- `pytest -q`


