### PR TITLE
Add toast notifications via Axios interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ uvicorn server:app --reload
 # Frontend
 cd ../frontend
 yarn install
+yarn add react-toastify # falls nicht bereits installiert
 yarn start
 ```
 
@@ -135,6 +136,11 @@ Mit `docker-compose up --build` werden alle Container (MongoDB, Backend, Fronten
 
 - `src/components` – React-Komponenten für Dashboard und CMS
 - `src/__tests__` – Frontend-Tests mit Jest/React Testing Library
+- `src/services/axiosInterceptor.js` – registriert einen Axios-Interceptor, der
+  HTTP-Fehler per Toast anzeigt
+
+Beim Laden von `src/index.js` wird dieser Interceptor automatisch aktiviert, so
+dass API-Fehler als Benachrichtigung erscheinen.
 
 ## 🧪 Tests ausführen
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.5.1",
-    "react-scripts": "5.0.1"
+    "react-scripts": "5.0.1",
+    "react-toastify": "^11.0.5"
   },
   "scripts": {
     "start": "craco start",
@@ -46,8 +47,8 @@
     "eslint-plugin-react": "7.37.4",
     "globals": "15.15.0",
     "postcss": "^8.4.49",
-    "tailwindcss": "^3.4.17",
-    "prettier": "^3.2.5"
+    "prettier": "^3.2.5",
+    "tailwindcss": "^3.4.17"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import Login from './components/Login';
 import Dashboard from './components/Dashboard';
 import Layout from './components/Layout';
 import axios from 'axios';
+import { ToastContainer } from 'react-toastify';
 import {
   registerUserIfNeeded,
   fetchUserFromServer,
@@ -98,6 +99,7 @@ const ProtectedRoute = ({ children }) => {
 function App() {
   return (
     <AuthProvider>
+      <ToastContainer />
       <div className="App">
         <BrowserRouter>
           <Routes>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,6 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import 'react-toastify/dist/ReactToastify.css';
+import { registerAxiosInterceptor } from './services/axiosInterceptor';
+
+registerAxiosInterceptor();
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/frontend/src/services/axiosInterceptor.js
+++ b/frontend/src/services/axiosInterceptor.js
@@ -1,0 +1,14 @@
+import axios from 'axios';
+import { toast } from 'react-toastify';
+
+export function registerAxiosInterceptor() {
+  axios.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      const message =
+        error?.response?.data?.detail || error.message || 'Request failed';
+      toast.error(message);
+      return Promise.reject(error);
+    },
+  );
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3810,6 +3810,11 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -8746,6 +8751,13 @@ react-scripts@5.0.1:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
+
+react-toastify@^11.0.5:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-11.0.5.tgz#ce4c42d10eeb433988ab2264d3e445c4e9d13313"
+  integrity sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==
+  dependencies:
+    clsx "^2.1.1"
 
 react@^19.0.0:
   version "19.0.0"


### PR DESCRIPTION
## Summary
- add `react-toastify` dependency
- register Axios response interceptor in `src/index.js`
- show `<ToastContainer />` in `App`
- document installation and use of toast notifications

## Testing
- `pytest -q`
- `yarn test --watchAll=false`
