### PR TITLE
Add content endpoint tests

### DIFF
--- a/test_result.md
+++ b/test_result.md
@@ -172,6 +172,17 @@ frontend:
       - working: true
         agent: "main"
         comment: "Added auth service and refactored App.js"
+  - task: "Content endpoint tests"
+    implemented: true
+    working: true
+    file: "tests/test_content_endpoints.py"
+    stuck_count: 0
+    priority: "medium"
+    needs_retesting: true
+    status_history:
+      - working: true
+        agent: "main"
+        comment: "Added CRUD tests for pages and articles with role checks"
 metadata:
   created_by: "main_agent"
   version: "1.0"
@@ -183,6 +194,7 @@ test_plan:
     - "Linting configuration"
     - "Frontend linting setup"
     - "Auth service integration"
+    - "Content endpoint tests"
   stuck_tasks: []
   test_all: false
   test_priority: "high_first"
@@ -195,3 +207,5 @@ agent_communication:
     message: "Fixed CI failure by updating yarn.lock and running Prettier"
   - agent: "main"
     message: "Added frontend auth service and updated App.js"
+  - agent: "main"
+    message: "Added CRUD tests for pages and articles"

--- a/tests/test_content_endpoints.py
+++ b/tests/test_content_endpoints.py
@@ -89,3 +89,148 @@ def test_delete_article_as_editor(client, fake_db, monkeypatch):
     response = client.delete(f"/api/articles/{article_doc['id']}", headers=headers)
     assert response.status_code == 200
     assert article_doc["id"] not in fake_db.articles.storage
+
+
+def test_create_article(client, mock_firebase, seed_user):
+    payload = {"title": "Test Article", "slug": "test-article", "content": "Body"}
+    headers = {"Authorization": "Bearer faketoken"}
+    response = client.post("/api/articles", json=payload, headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == payload["title"]
+
+
+def test_update_article_by_author(client, fake_db, monkeypatch):
+    from firebase_admin import auth as firebase_auth
+
+    def fake_verify(token):
+        return {"uid": "authoruid"}
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", fake_verify)
+
+    author_doc = {
+        "id": "author2",
+        "firebase_uid": "authoruid",
+        "email": "author2@example.com",
+        "name": "Author2",
+        "role": UserRole.AUTHOR.value,
+        "created_at": datetime.datetime.utcnow(),
+        "updated_at": datetime.datetime.utcnow(),
+        "is_active": True,
+    }
+    fake_db.users.storage[author_doc["firebase_uid"]] = author_doc
+
+    article_doc = {
+        "id": "art2",
+        "title": "Old",
+        "slug": "old",
+        "content": "c",
+        "author_id": author_doc["id"],
+        "status": "draft",
+        "created_at": datetime.datetime.utcnow(),
+        "updated_at": datetime.datetime.utcnow(),
+    }
+    fake_db.articles.storage[article_doc["id"]] = article_doc
+
+    headers = {"Authorization": "Bearer token"}
+    response = client.put(
+        f"/api/articles/{article_doc['id']}",
+        json={"title": "New"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert fake_db.articles.storage[article_doc["id"]]["title"] == "New"
+
+
+def test_delete_page_as_editor(client, fake_db, monkeypatch):
+    from firebase_admin import auth as firebase_auth
+
+    def fake_verify(token):
+        return {"uid": "editoruid"}
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", fake_verify)
+
+    editor_doc = {
+        "id": "editor2",
+        "firebase_uid": "editoruid",
+        "email": "editor2@example.com",
+        "name": "Editor2",
+        "role": UserRole.EDITOR.value,
+        "created_at": datetime.datetime.utcnow(),
+        "updated_at": datetime.datetime.utcnow(),
+        "is_active": True,
+    }
+    fake_db.users.storage[editor_doc["firebase_uid"]] = editor_doc
+
+    page_doc = {
+        "id": "page2",
+        "title": "Old",
+        "slug": "old",
+        "content": "c",
+        "author_id": editor_doc["id"],
+        "status": "draft",
+        "created_at": datetime.datetime.utcnow(),
+        "updated_at": datetime.datetime.utcnow(),
+    }
+    fake_db.pages.storage[page_doc["id"]] = page_doc
+
+    headers = {"Authorization": "Bearer token"}
+    response = client.delete(f"/api/pages/{page_doc['id']}", headers=headers)
+    assert response.status_code == 200
+    assert page_doc["id"] not in fake_db.pages.storage
+
+
+def test_create_page_denied_for_viewer(client, fake_db, monkeypatch):
+    from firebase_admin import auth as firebase_auth
+
+    def fake_verify(token):
+        return {"uid": "vieweruid"}
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", fake_verify)
+
+    viewer_doc = {
+        "id": "viewer1",
+        "firebase_uid": "vieweruid",
+        "email": "viewer@example.com",
+        "name": "Viewer",
+        "role": UserRole.VIEWER.value,
+        "created_at": datetime.datetime.utcnow(),
+        "updated_at": datetime.datetime.utcnow(),
+        "is_active": True,
+    }
+    fake_db.users.storage[viewer_doc["firebase_uid"]] = viewer_doc
+
+    payload = {"title": "Denied", "slug": "denied", "content": "c"}
+    headers = {"Authorization": "Bearer viewertoken"}
+    response = client.post("/api/pages", json=payload, headers=headers)
+    assert response.status_code == 403
+    data = response.json()
+    assert data["error"]["message"] == "Insufficient permissions"
+
+
+def test_create_article_denied_for_viewer(client, fake_db, monkeypatch):
+    from firebase_admin import auth as firebase_auth
+
+    def fake_verify(token):
+        return {"uid": "vieweruid"}
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", fake_verify)
+
+    viewer_doc = {
+        "id": "viewer2",
+        "firebase_uid": "vieweruid",
+        "email": "viewer2@example.com",
+        "name": "Viewer2",
+        "role": UserRole.VIEWER.value,
+        "created_at": datetime.datetime.utcnow(),
+        "updated_at": datetime.datetime.utcnow(),
+        "is_active": True,
+    }
+    fake_db.users.storage[viewer_doc["firebase_uid"]] = viewer_doc
+
+    payload = {"title": "Denied", "slug": "denied", "content": "c"}
+    headers = {"Authorization": "Bearer viewertoken"}
+    response = client.post("/api/articles", json=payload, headers=headers)
+    assert response.status_code == 403
+    data = response.json()
+    assert data["error"]["message"] == "Insufficient permissions"


### PR DESCRIPTION
## Summary
- cover article CRUD operations and viewer restrictions in tests
- update test planning data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873ea3aa07c832e99ebe8702d0cf502