### PR TITLE
Add axios interceptor toast test

### DIFF
--- a/frontend/src/__tests__/axiosInterceptor.test.js
+++ b/frontend/src/__tests__/axiosInterceptor.test.js
@@ -1,0 +1,33 @@
+import axios from 'axios';
+import { registerAxiosInterceptor } from '../services/axiosInterceptor';
+import { toast } from 'react-toastify';
+
+jest.mock('axios', () => ({
+  interceptors: {
+    response: {
+      use: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    error: jest.fn(),
+  },
+}));
+
+describe('axios interceptor', () => {
+  it('displays toast on failed request', async () => {
+    registerAxiosInterceptor();
+
+    // Capture the error handler registered with axios
+    const errorHandler = axios.interceptors.response.use.mock.calls[0][1];
+
+    const error = { response: { data: { detail: 'Request failed' } } };
+
+    // Invoke the interceptor's error handler
+    await expect(errorHandler(error)).rejects.toBe(error);
+
+    expect(toast.error).toHaveBeenCalledWith('Request failed');
+  });
+});

--- a/test_result.md
+++ b/test_result.md
@@ -183,6 +183,18 @@ frontend:
       - working: true
         agent: "main"
         comment: "Added CRUD tests for pages and articles with role checks"
+  - task: "Axios interceptor toast errors"
+    implemented: true
+    working: true
+    file: "frontend/src/services/axiosInterceptor.js"
+    stuck_count: 0
+    priority: "medium"
+    needs_retesting: true
+    status_history:
+      - working: true
+        agent: "main"
+        comment: "Added unit test verifying toast.error on failed request"
+
 metadata:
   created_by: "main_agent"
   version: "1.0"
@@ -209,3 +221,5 @@ agent_communication:
     message: "Added frontend auth service and updated App.js"
   - agent: "main"
     message: "Added CRUD tests for pages and articles"
+  - agent: "main"
+    message: "Added axios interceptor test triggering toast error"


### PR DESCRIPTION
## Summary
- add axios interceptor unit test verifying toast.error on failed request
- log new frontend test in testing records

## Testing
- `yarn test --watchAll=false`
